### PR TITLE
add repository data to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "description": "Encode and decode Tender Multipass tokens",
   "version": "1.0.0",
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "^10"
   },
   "keywords": ["sso", "tender", "multipass"],
   "main": "./lib/multipass",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/activeprospect/node-multipass"
+  }
   "scripts": {
     "test": "make test"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/activeprospect/node-multipass"
-  }
+  },
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
Internal AP dependency-testing scripts need a valid repo URL.
Also pinned `mocha` to ^10.